### PR TITLE
Add Laravel scaffolding for key modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # gestionalecv
+
+This repository contains placeholder Laravel structures for future development.
+
+## Modules
+
+The following service classes, models, migrations, and basic routes are included as starting points:
+
+- **Volunteer**: `app/Models/Volunteer.php`, `app/Services/VolunteerService.php`, migration in `database/migrations`, and route in `routes/api.php`.
+- **Vehicle**: `app/Models/Vehicle.php`, `app/Services/VehicleService.php`, migration in `database/migrations`, and route in `routes/api.php`.
+- **Checklist**: `app/Models/Checklist.php`, `app/Services/ChecklistService.php`, migration in `database/migrations`, and route in `routes/api.php`.
+
+These files act as scaffolding for future business logic and database schema design.

--- a/app/Models/Checklist.php
+++ b/app/Models/Checklist.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Checklist extends Model
+{
+    // TODO: define fillable fields and relationships
+}

--- a/app/Models/Vehicle.php
+++ b/app/Models/Vehicle.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Vehicle extends Model
+{
+    // TODO: define fillable fields and relationships
+}

--- a/app/Models/Volunteer.php
+++ b/app/Models/Volunteer.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Volunteer extends Model
+{
+    // TODO: define fillable fields and relationships
+}

--- a/app/Services/ChecklistService.php
+++ b/app/Services/ChecklistService.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Services;
+
+class ChecklistService
+{
+    // TODO: implement checklist related logic
+}

--- a/app/Services/VehicleService.php
+++ b/app/Services/VehicleService.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Services;
+
+class VehicleService
+{
+    // TODO: implement vehicle related logic
+}

--- a/app/Services/VolunteerService.php
+++ b/app/Services/VolunteerService.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Services;
+
+class VolunteerService
+{
+    // TODO: implement volunteer related logic
+}

--- a/database/migrations/2024_01_01_000000_create_volunteers_table.php
+++ b/database/migrations/2024_01_01_000000_create_volunteers_table.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('volunteers', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('volunteers');
+    }
+};

--- a/database/migrations/2024_01_01_000001_create_vehicles_table.php
+++ b/database/migrations/2024_01_01_000001_create_vehicles_table.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('vehicles', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('vehicles');
+    }
+};

--- a/database/migrations/2024_01_01_000002_create_checklists_table.php
+++ b/database/migrations/2024_01_01_000002_create_checklists_table.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('checklists', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('checklists');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/volunteers', function () {
+    // TODO: return volunteers list
+});
+
+Route::get('/vehicles', function () {
+    // TODO: return vehicles list
+});
+
+Route::get('/checklists', function () {
+    // TODO: return checklists list
+});


### PR DESCRIPTION
## Summary
- create placeholder Laravel models and services
- add example migrations for Volunteer, Vehicle, and Checklist
- define basic API routes
- document modules in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6861b1a1686c8324a053089aa2895ab5