### PR TITLE
Initialize basic Laravel API skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# gestionalecv
+# Gestionale Croce Verde
 
+Questo progetto Laravel fornisce un'API di base per la gestione di volontari, mezzi e checklist dell'associazione "Croce Verde Ascoli Piceno".
+
+## Requisiti
+- PHP >= 8.2
+- Composer
+
+## Installazione
+1. Copiare `.env.example` in `.env` e configurare i parametri del database.
+2. Eseguire `composer install` per installare le dipendenze.
+3. Lanciare le migrazioni con `php artisan migrate`.
+4. Avviare l'applicazione con `php artisan serve` oppure tramite docker-compose.
+
+## Funzionalità
+- CRUD volontari
+- CRUD mezzi
+- CRUD checklist
+
+Le rotte API sono definite in `routes/api.php`.

--- a/app/Http/Controllers/ChecklistController.php
+++ b/app/Http/Controllers/ChecklistController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Checklist;
+use Illuminate\Http\Request;
+
+class ChecklistController extends Controller
+{
+    public function index()
+    {
+        return Checklist::all();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'vehicle_id' => 'nullable|exists:vehicles,id',
+            'name' => 'required|string',
+            'description' => 'nullable|string',
+            'compliant' => 'boolean',
+        ]);
+
+        return Checklist::create($data);
+    }
+
+    public function show(Checklist $checklist)
+    {
+        return $checklist;
+    }
+
+    public function update(Request $request, Checklist $checklist)
+    {
+        $data = $request->validate([
+            'vehicle_id' => 'nullable|exists:vehicles,id',
+            'name' => 'sometimes|required|string',
+            'description' => 'nullable|string',
+            'compliant' => 'boolean',
+        ]);
+
+        $checklist->update($data);
+        return $checklist;
+    }
+
+    public function destroy(Checklist $checklist)
+    {
+        $checklist->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/VehicleController.php
+++ b/app/Http/Controllers/VehicleController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Vehicle;
+use Illuminate\Http\Request;
+
+class VehicleController extends Controller
+{
+    public function index()
+    {
+        return Vehicle::all();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'type' => 'required|string',
+            'license_plate' => 'required|string|unique:vehicles,license_plate',
+            'model' => 'nullable|string',
+            'registration_date' => 'nullable|date',
+            'insurance_expiry' => 'nullable|date',
+            'inspection_expiry' => 'nullable|date',
+        ]);
+
+        return Vehicle::create($data);
+    }
+
+    public function show(Vehicle $vehicle)
+    {
+        return $vehicle;
+    }
+
+    public function update(Request $request, Vehicle $vehicle)
+    {
+        $data = $request->validate([
+            'type' => 'sometimes|required|string',
+            'license_plate' => 'sometimes|required|string|unique:vehicles,license_plate,' . $vehicle->id,
+            'model' => 'nullable|string',
+            'registration_date' => 'nullable|date',
+            'insurance_expiry' => 'nullable|date',
+            'inspection_expiry' => 'nullable|date',
+        ]);
+
+        $vehicle->update($data);
+        return $vehicle;
+    }
+
+    public function destroy(Vehicle $vehicle)
+    {
+        $vehicle->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/VolunteerController.php
+++ b/app/Http/Controllers/VolunteerController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Volunteer;
+use Illuminate\Http\Request;
+
+class VolunteerController extends Controller
+{
+    public function index()
+    {
+        return Volunteer::all();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'first_name' => 'required|string',
+            'last_name' => 'required|string',
+            'email' => 'required|email|unique:volunteers,email',
+            'phone' => 'nullable|string',
+            'tax_code' => 'required|string|unique:volunteers,tax_code',
+            'role' => 'required|string',
+            'licenses' => 'nullable|string',
+        ]);
+
+        return Volunteer::create($data);
+    }
+
+    public function show(Volunteer $volunteer)
+    {
+        return $volunteer;
+    }
+
+    public function update(Request $request, Volunteer $volunteer)
+    {
+        $data = $request->validate([
+            'first_name' => 'sometimes|required|string',
+            'last_name' => 'sometimes|required|string',
+            'email' => 'sometimes|required|email|unique:volunteers,email,' . $volunteer->id,
+            'phone' => 'nullable|string',
+            'tax_code' => 'sometimes|required|string|unique:volunteers,tax_code,' . $volunteer->id,
+            'role' => 'sometimes|required|string',
+            'licenses' => 'nullable|string',
+        ]);
+
+        $volunteer->update($data);
+        return $volunteer;
+    }
+
+    public function destroy(Volunteer $volunteer)
+    {
+        $volunteer->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Models/Checklist.php
+++ b/app/Models/Checklist.php
@@ -10,6 +10,9 @@ class Checklist extends Model
     use HasFactory;
 
     protected $fillable = [
-        // TODO: add fillable columns
+        'vehicle_id',
+        'name',
+        'description',
+        'compliant',
     ];
 }

--- a/app/Models/Vehicle.php
+++ b/app/Models/Vehicle.php
@@ -10,6 +10,11 @@ class Vehicle extends Model
     use HasFactory;
 
     protected $fillable = [
-        // TODO: add fillable columns
+        'type',
+        'license_plate',
+        'model',
+        'registration_date',
+        'insurance_expiry',
+        'inspection_expiry',
     ];
 }

--- a/app/Models/Volunteer.php
+++ b/app/Models/Volunteer.php
@@ -10,6 +10,12 @@ class Volunteer extends Model
     use HasFactory;
 
     protected $fillable = [
-        // TODO: add fillable columns
+        'first_name',
+        'last_name',
+        'email',
+        'phone',
+        'tax_code',
+        'role',
+        'licenses',
     ];
 }

--- a/app/Services/ChecklistService.php
+++ b/app/Services/ChecklistService.php
@@ -2,7 +2,28 @@
 
 namespace App\Services;
 
+use App\Models\Checklist;
+
 class ChecklistService
 {
-    // TODO: implement checklist related business logic
+    public function all()
+    {
+        return Checklist::all();
+    }
+
+    public function create(array $data)
+    {
+        return Checklist::create($data);
+    }
+
+    public function update(Checklist $checklist, array $data)
+    {
+        $checklist->update($data);
+        return $checklist;
+    }
+
+    public function delete(Checklist $checklist): void
+    {
+        $checklist->delete();
+    }
 }

--- a/app/Services/VehicleService.php
+++ b/app/Services/VehicleService.php
@@ -2,7 +2,28 @@
 
 namespace App\Services;
 
+use App\Models\Vehicle;
+
 class VehicleService
 {
-    // TODO: implement vehicle related business logic
+    public function all()
+    {
+        return Vehicle::all();
+    }
+
+    public function create(array $data)
+    {
+        return Vehicle::create($data);
+    }
+
+    public function update(Vehicle $vehicle, array $data)
+    {
+        $vehicle->update($data);
+        return $vehicle;
+    }
+
+    public function delete(Vehicle $vehicle): void
+    {
+        $vehicle->delete();
+    }
 }

--- a/app/Services/VolunteerService.php
+++ b/app/Services/VolunteerService.php
@@ -2,7 +2,28 @@
 
 namespace App\Services;
 
+use App\Models\Volunteer;
+
 class VolunteerService
 {
-    // TODO: implement volunteer related business logic
+    public function all()
+    {
+        return Volunteer::all();
+    }
+
+    public function create(array $data)
+    {
+        return Volunteer::create($data);
+    }
+
+    public function update(Volunteer $volunteer, array $data)
+    {
+        $volunteer->update($data);
+        return $volunteer;
+    }
+
+    public function delete(Volunteer $volunteer): void
+    {
+        $volunteer->delete();
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "croce-verde/gestionale-cv",
+    "description": "Gestione Associazione Croce Verde Ascoli Piceno",
+    "type": "project",
+    "require": {
+        "php": "^8.2",
+        "laravel/framework": "^11.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    },
+    "scripts": {
+        "start": "php artisan serve"
+    }
+}

--- a/database/migrations/2024_01_01_000000_create_volunteers_table.php
+++ b/database/migrations/2024_01_01_000000_create_volunteers_table.php
@@ -10,6 +10,13 @@ return new class extends Migration
     {
         Schema::create('volunteers', function (Blueprint $table) {
             $table->id();
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->string('email')->unique();
+            $table->string('phone')->nullable();
+            $table->string('tax_code')->unique();
+            $table->string('role');
+            $table->string('licenses')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_01_01_000001_create_vehicles_table.php
+++ b/database/migrations/2024_01_01_000001_create_vehicles_table.php
@@ -10,6 +10,12 @@ return new class extends Migration
     {
         Schema::create('vehicles', function (Blueprint $table) {
             $table->id();
+            $table->string('type');
+            $table->string('license_plate')->unique();
+            $table->string('model')->nullable();
+            $table->date('registration_date')->nullable();
+            $table->date('insurance_expiry')->nullable();
+            $table->date('inspection_expiry')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_01_01_000002_create_checklists_table.php
+++ b/database/migrations/2024_01_01_000002_create_checklists_table.php
@@ -10,6 +10,10 @@ return new class extends Migration
     {
         Schema::create('checklists', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('vehicle_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->boolean('compliant')->default(true);
             $table->timestamps();
         });
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,18 +1,10 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\VolunteerController;
+use App\Http\Controllers\VehicleController;
+use App\Http\Controllers\ChecklistController;
 
-// Volunteer routes
-Route::prefix('volunteers')->group(function () {
-    // TODO: add volunteer endpoints
-});
-
-// Vehicle routes
-Route::prefix('vehicles')->group(function () {
-    // TODO: add vehicle endpoints
-});
-
-// Checklist routes
-Route::prefix('checklists')->group(function () {
-    // TODO: add checklist endpoints
-});
+Route::apiResource('volunteers', VolunteerController::class);
+Route::apiResource('vehicles', VehicleController::class);
+Route::apiResource('checklists', ChecklistController::class);


### PR DESCRIPTION
## Summary
- create composer.json and update README
- flesh out migrations for volunteers, vehicles and checklists
- implement Eloquent models with fillable properties
- add service classes for basic CRUD logic
- add controllers and API routes for volunteers, vehicles and checklists

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6861b4db94348324b2d711377379d5f1