### PR TITLE
Add basic document management

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ Questo progetto Laravel fornisce un'API di base per la gestione di volontari, me
 - CRUD volontari
 - CRUD mezzi
 - CRUD checklist
+- CRUD documenti (allegabili a volontari o mezzi)
 
 Le rotte API sono definite in `routes/api.php`.

--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Document;
+use Illuminate\Http\Request;
+
+class DocumentController extends Controller
+{
+    public function index()
+    {
+        return Document::all();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'volunteer_id' => 'nullable|exists:volunteers,id',
+            'vehicle_id' => 'nullable|exists:vehicles,id',
+            'category' => 'required|string',
+            'name' => 'required|string',
+            'path' => 'required|string',
+            'expiry_date' => 'nullable|date',
+        ]);
+
+        return Document::create($data);
+    }
+
+    public function show(Document $document)
+    {
+        return $document;
+    }
+
+    public function update(Request $request, Document $document)
+    {
+        $data = $request->validate([
+            'volunteer_id' => 'nullable|exists:volunteers,id',
+            'vehicle_id' => 'nullable|exists:vehicles,id',
+            'category' => 'sometimes|required|string',
+            'name' => 'sometimes|required|string',
+            'path' => 'sometimes|required|string',
+            'expiry_date' => 'nullable|date',
+        ]);
+
+        $document->update($data);
+        return $document;
+    }
+
+    public function destroy(Document $document)
+    {
+        $document->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Document extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'volunteer_id',
+        'vehicle_id',
+        'category',
+        'name',
+        'path',
+        'expiry_date',
+    ];
+
+    public function volunteer()
+    {
+        return $this->belongsTo(Volunteer::class);
+    }
+
+    public function vehicle()
+    {
+        return $this->belongsTo(Vehicle::class);
+    }
+}

--- a/database/migrations/2024_01_01_000003_create_documents_table.php
+++ b/database/migrations/2024_01_01_000003_create_documents_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('documents', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('volunteer_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->foreignId('vehicle_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->string('category');
+            $table->string('name');
+            $table->string('path');
+            $table->date('expiry_date')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('documents');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,7 +4,9 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\VolunteerController;
 use App\Http\Controllers\VehicleController;
 use App\Http\Controllers\ChecklistController;
+use App\Http\Controllers\DocumentController;
 
 Route::apiResource('volunteers', VolunteerController::class);
 Route::apiResource('vehicles', VehicleController::class);
 Route::apiResource('checklists', ChecklistController::class);
+Route::apiResource('documents', DocumentController::class);


### PR DESCRIPTION
## Summary
- add Document model and migration
- create DocumentController with CRUD endpoints
- expose `documents` API routes
- mention document module in README

## Testing
- `php artisan migrate --pretend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b9a876d48324bd4b210c6f7477ba