### PR TITLE
Add basic ACL and logging modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,8 @@ Questo progetto Laravel fornisce un'API di base per la gestione di volontari, me
 - CRUD volontari
 - CRUD mezzi
 - CRUD checklist
+- CRUD documenti (allegabili a volontari o mezzi)
+- CRUD DPI (assegnazione dispositivi di protezione ai volontari)
+- Gestione ruoli e permessi (ACL) con registrazione log accessi
 
 Le rotte API sono definite in `routes/api.php`.

--- a/app/Http/Controllers/AccessLogController.php
+++ b/app/Http/Controllers/AccessLogController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\AccessLog;
+use Illuminate\Http\Request;
+
+class AccessLogController extends Controller
+{
+    public function index()
+    {
+        return AccessLog::with('volunteer')->get();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'volunteer_id' => 'required|exists:volunteers,id',
+            'action' => 'required|string',
+            'description' => 'nullable|string',
+        ]);
+
+        return AccessLog::create($data);
+    }
+
+    public function show(AccessLog $accessLog)
+    {
+        return $accessLog->load('volunteer');
+    }
+
+    public function update(Request $request, AccessLog $accessLog)
+    {
+        $data = $request->validate([
+            'volunteer_id' => 'sometimes|required|exists:volunteers,id',
+            'action' => 'sometimes|required|string',
+            'description' => 'nullable|string',
+        ]);
+
+        $accessLog->update($data);
+        return $accessLog->load('volunteer');
+    }
+
+    public function destroy(AccessLog $accessLog)
+    {
+        $accessLog->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Document;
+use Illuminate\Http\Request;
+
+class DocumentController extends Controller
+{
+    public function index()
+    {
+        return Document::all();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'volunteer_id' => 'nullable|exists:volunteers,id',
+            'vehicle_id' => 'nullable|exists:vehicles,id',
+            'category' => 'required|string',
+            'name' => 'required|string',
+            'path' => 'required|string',
+            'expiry_date' => 'nullable|date',
+        ]);
+
+        return Document::create($data);
+    }
+
+    public function show(Document $document)
+    {
+        return $document;
+    }
+
+    public function update(Request $request, Document $document)
+    {
+        $data = $request->validate([
+            'volunteer_id' => 'nullable|exists:volunteers,id',
+            'vehicle_id' => 'nullable|exists:vehicles,id',
+            'category' => 'sometimes|required|string',
+            'name' => 'sometimes|required|string',
+            'path' => 'sometimes|required|string',
+            'expiry_date' => 'nullable|date',
+        ]);
+
+        $document->update($data);
+        return $document;
+    }
+
+    public function destroy(Document $document)
+    {
+        $document->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/DpiController.php
+++ b/app/Http/Controllers/DpiController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Dpi;
+use Illuminate\Http\Request;
+
+class DpiController extends Controller
+{
+    public function index()
+    {
+        return Dpi::all();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'volunteer_id' => 'required|exists:volunteers,id',
+            'name' => 'required|string',
+            'assigned_at' => 'required|date',
+            'expiry_date' => 'nullable|date',
+        ]);
+
+        return Dpi::create($data);
+    }
+
+    public function show(Dpi $dpi)
+    {
+        return $dpi;
+    }
+
+    public function update(Request $request, Dpi $dpi)
+    {
+        $data = $request->validate([
+            'volunteer_id' => 'sometimes|required|exists:volunteers,id',
+            'name' => 'sometimes|required|string',
+            'assigned_at' => 'sometimes|required|date',
+            'expiry_date' => 'nullable|date',
+        ]);
+
+        $dpi->update($data);
+        return $dpi;
+    }
+
+    public function destroy(Dpi $dpi)
+    {
+        $dpi->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/PermissionController.php
+++ b/app/Http/Controllers/PermissionController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Permission;
+use Illuminate\Http\Request;
+
+class PermissionController extends Controller
+{
+    public function index()
+    {
+        return Permission::all();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|unique:permissions,name',
+        ]);
+
+        return Permission::create($data);
+    }
+
+    public function show(Permission $permission)
+    {
+        return $permission;
+    }
+
+    public function update(Request $request, Permission $permission)
+    {
+        $data = $request->validate([
+            'name' => 'sometimes|required|string|unique:permissions,name,' . $permission->id,
+        ]);
+
+        $permission->update($data);
+        return $permission;
+    }
+
+    public function destroy(Permission $permission)
+    {
+        $permission->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Role;
+use Illuminate\Http\Request;
+
+class RoleController extends Controller
+{
+    public function index()
+    {
+        return Role::with('permissions')->get();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|unique:roles,name',
+            'permission_ids' => 'array',
+            'permission_ids.*' => 'exists:permissions,id',
+        ]);
+
+        $role = Role::create(['name' => $data['name']]);
+        if (!empty($data['permission_ids'])) {
+            $role->permissions()->sync($data['permission_ids']);
+        }
+
+        return $role->load('permissions');
+    }
+
+    public function show(Role $role)
+    {
+        return $role->load('permissions');
+    }
+
+    public function update(Request $request, Role $role)
+    {
+        $data = $request->validate([
+            'name' => 'sometimes|required|string|unique:roles,name,' . $role->id,
+            'permission_ids' => 'array',
+            'permission_ids.*' => 'exists:permissions,id',
+        ]);
+
+        if (isset($data['name'])) {
+            $role->name = $data['name'];
+            $role->save();
+        }
+        if (isset($data['permission_ids'])) {
+            $role->permissions()->sync($data['permission_ids']);
+        }
+
+        return $role->load('permissions');
+    }
+
+    public function destroy(Role $role)
+    {
+        $role->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Models/AccessLog.php
+++ b/app/Models/AccessLog.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AccessLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['volunteer_id', 'action', 'description'];
+
+    public function volunteer()
+    {
+        return $this->belongsTo(Volunteer::class);
+    }
+}

--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Document extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'volunteer_id',
+        'vehicle_id',
+        'category',
+        'name',
+        'path',
+        'expiry_date',
+    ];
+
+    public function volunteer()
+    {
+        return $this->belongsTo(Volunteer::class);
+    }
+
+    public function vehicle()
+    {
+        return $this->belongsTo(Vehicle::class);
+    }
+}

--- a/app/Models/Dpi.php
+++ b/app/Models/Dpi.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Dpi extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'volunteer_id',
+        'name',
+        'assigned_at',
+        'expiry_date',
+    ];
+
+    public function volunteer()
+    {
+        return $this->belongsTo(Volunteer::class);
+    }
+}

--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Permission extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name'];
+
+    public function roles()
+    {
+        return $this->belongsToMany(Role::class);
+    }
+}

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Role extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name'];
+
+    public function volunteers()
+    {
+        return $this->belongsToMany(Volunteer::class);
+    }
+
+    public function permissions()
+    {
+        return $this->belongsToMany(Permission::class);
+    }
+}

--- a/app/Models/Volunteer.php
+++ b/app/Models/Volunteer.php
@@ -18,4 +18,14 @@ class Volunteer extends Model
         'role',
         'licenses',
     ];
+
+    public function roles()
+    {
+        return $this->belongsToMany(Role::class);
+    }
+
+    public function accessLogs()
+    {
+        return $this->hasMany(AccessLog::class);
+    }
 }

--- a/database/migrations/2024_01_01_000003_create_documents_table.php
+++ b/database/migrations/2024_01_01_000003_create_documents_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('documents', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('volunteer_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->foreignId('vehicle_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->string('category');
+            $table->string('name');
+            $table->string('path');
+            $table->date('expiry_date')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('documents');
+    }
+};

--- a/database/migrations/2024_01_01_000004_create_dpis_table.php
+++ b/database/migrations/2024_01_01_000004_create_dpis_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('dpis', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('volunteer_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->date('assigned_at');
+            $table->date('expiry_date')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('dpis');
+    }
+};

--- a/database/migrations/2024_01_01_000005_create_roles_table.php
+++ b/database/migrations/2024_01_01_000005_create_roles_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+
+        Schema::create('permission_role', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+
+        Schema::create('role_volunteer', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('volunteer_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('role_volunteer');
+        Schema::dropIfExists('permission_role');
+        Schema::dropIfExists('roles');
+    }
+};

--- a/database/migrations/2024_01_01_000006_create_permissions_table.php
+++ b/database/migrations/2024_01_01_000006_create_permissions_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('permissions');
+    }
+};

--- a/database/migrations/2024_01_01_000007_create_access_logs_table.php
+++ b/database/migrations/2024_01_01_000007_create_access_logs_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('access_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('volunteer_id')->constrained()->cascadeOnDelete();
+            $table->string('action');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('access_logs');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,7 +4,17 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\VolunteerController;
 use App\Http\Controllers\VehicleController;
 use App\Http\Controllers\ChecklistController;
+use App\Http\Controllers\DocumentController;
+use App\Http\Controllers\DpiController;
+use App\Http\Controllers\RoleController;
+use App\Http\Controllers\PermissionController;
+use App\Http\Controllers\AccessLogController;
 
 Route::apiResource('volunteers', VolunteerController::class);
 Route::apiResource('vehicles', VehicleController::class);
 Route::apiResource('checklists', ChecklistController::class);
+Route::apiResource('documents', DocumentController::class);
+Route::apiResource('dpis', DpiController::class);
+Route::apiResource('roles', RoleController::class);
+Route::apiResource('permissions', PermissionController::class);
+Route::apiResource('access-logs', AccessLogController::class);


### PR DESCRIPTION
## Summary
- create Role, Permission and AccessLog models with migrations
- implement RoleController, PermissionController and AccessLogController
- register new API routes for ACL and logging
- document new ACL feature in README

## Testing
- `php artisan migrate --pretend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b9a876d48324bd4b210c6f7477ba