### PR TITLE
Fix user ordering

### DIFF
--- a/app/Http/Controllers/NotificheController.php
+++ b/app/Http/Controllers/NotificheController.php
@@ -99,7 +99,8 @@ class NotificheController extends Controller
             }
 
             $utenti = User::where('id', '!=', Auth::id())
-                         ->orderBy('name')
+                         ->orderBy('cognome')
+                         ->orderBy('nome')
                          ->get();
 
             $volontari = Volontario::where('stato', 'attivo')


### PR DESCRIPTION
## Summary
- order notifications by `cognome` then `nome` instead of the invalid `name` column

## Testing
- `./vendor/bin/phpunit --testdox` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cd8736c083249c376bf182bd7ce4