### PR TITLE
Update notifiche permission calls

### DIFF
--- a/app/Http/Controllers/NotificheController.php
+++ b/app/Http/Controllers/NotificheController.php
@@ -94,7 +94,7 @@ class NotificheController extends Controller
     {
         try {
             // Solo admin e responsabili possono creare notifiche
-            if (!Auth::user()->hasPermission('notifiche.create')) {
+            if (!Auth::user()->hasPermission('notifiche', 'create')) {
                 abort(403, 'Non hai i permessi per creare notifiche');
             }
 
@@ -217,7 +217,7 @@ class NotificheController extends Controller
     {
         try {
             // Verifica che l'utente possa vedere questa notifica
-            if ($notifica->user_id !== Auth::id() && !Auth::user()->hasPermission('notifiche.view_all')) {
+            if ($notifica->user_id !== Auth::id() && !Auth::user()->hasPermission('notifiche', 'view_all')) {
                 abort(403, 'Non autorizzato a visualizzare questa notifica');
             }
 
@@ -294,7 +294,7 @@ class NotificheController extends Controller
     {
         try {
             // Verifica che l'utente possa eliminare questa notifica
-            if ($notifica->user_id !== Auth::id() && !Auth::user()->hasPermission('notifiche.delete_all')) {
+            if ($notifica->user_id !== Auth::id() && !Auth::user()->hasPermission('notifiche', 'delete_all')) {
                 abort(403, 'Non autorizzato a eliminare questa notifica');
             }
 


### PR DESCRIPTION
## Summary
- update `hasPermission('notifiche.*')` calls to new two-argument form

## Testing
- `./vendor/bin/phpunit` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cd8a235c8324b016eaafd2c5ba93