### PR TITLE
Use full name for notifications

### DIFF
--- a/app/Http/Controllers/NotificheController.php
+++ b/app/Http/Controllers/NotificheController.php
@@ -169,7 +169,7 @@ class NotificheController extends Controller
                     'scade_il' => $validated['scade_il'],
                     'metadati' => json_encode([
                         'created_by' => Auth::id(),
-                        'created_by_name' => Auth::user()->name,
+                        'created_by_name' => Auth::user()->nome_completo,
                         'invia_email' => $validated['invia_email'] ?? false,
                         'invia_push' => $validated['invia_push'] ?? false
                     ])


### PR DESCRIPTION
## Summary
- ensure notification metadata uses `nome_completo` when storing the author name

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862cd8ce45083249791d1cb90d6d095