### PR TITLE
Use 'ruolo' field for document expiration notifications

### DIFF
--- a/app/Http/Controllers/NotificheController.php
+++ b/app/Http/Controllers/NotificheController.php
@@ -490,9 +490,9 @@ class NotificheController extends Controller
                     }
 
                     // Notifica ai responsabili
-                    $responsabili = User::whereHas('roles', function($q) {
-                        $q->whereIn('name', ['admin', 'responsabile']);
-                    })->get();
+                    $responsabili = User::whereIn('ruolo', ['admin', 'direttivo'])
+                        ->where('attivo', true)
+                        ->get();
 
                     self::createSystemNotification(
                         $responsabili,


### PR DESCRIPTION
## Summary
- adjust query for document expiration notifications

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862cd8ff2248324a5ea1366f5e9c748