### PR TITLE
Add notifiche table migration

### DIFF
--- a/database/migrations/2025_07_01_000000_create_notifiche_table.php
+++ b/database/migrations/2025_07_01_000000_create_notifiche_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notifiche', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+            $table->string('tipo');
+            $table->string('titolo');
+            $table->text('messaggio');
+            $table->enum('priorita', ['bassa', 'normale', 'alta', 'urgente'])->default('normale');
+            $table->string('url_azione', 500)->nullable();
+            $table->string('testo_azione', 100)->nullable();
+            $table->timestamp('scade_il')->nullable();
+            $table->json('metadati')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['user_id', 'tipo']);
+            $table->index('priorita');
+            $table->index('scade_il');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notifiche');
+    }
+};


### PR DESCRIPTION
## Summary
- add migration for `notifiche` table with fields referenced by `Notifica` model

## Testing
- `php artisan migrate --force` *(fails: `php` not found)*
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cd94a5b48324a2dd1edefea46a4e