### PR TITLE
Fix foreign key constraints in migrations

### DIFF
--- a/database/migrations/2024_01_01_000006_create_checklist_compilate_table.php
+++ b/database/migrations/2024_01_01_000006_create_checklist_compilate_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('checklist_compilate', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('mezzo_id')->constrained("users")->onDelete('cascade');
+            $table->foreignId('mezzo_id')->constrained('mezzi')->onDelete('cascade');
             $table->foreignId('user_id')->constrained("users")->onDelete('cascade');
             $table->foreignId('template_id')->constrained('checklist_templates')->onDelete('cascade');
             $table->json('risultati'); // Array con i risultati dei controlli

--- a/database/migrations/2024_01_01_000009_create_assegnazioni_dpi_table.php
+++ b/database/migrations/2024_01_01_000009_create_assegnazioni_dpi_table.php
@@ -13,8 +13,8 @@ return new class extends Migration
     {
         Schema::create('assegnazioni_dpi', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('dpi_id')->constrained("users")->onDelete('cascade');
-            $table->foreignId('volontario_id')->constrained("users")->onDelete('cascade');
+            $table->foreignId('dpi_id')->constrained('dpi')->onDelete('cascade');
+            $table->foreignId('volontario_id')->constrained('volontari')->onDelete('cascade');
             $table->foreignId('assegnato_da')->constrained('users')->onDelete('cascade');
             
             // Date assegnazione/restituzione

--- a/database/migrations/2024_01_01_000010_create_documenti_table.php
+++ b/database/migrations/2024_01_01_000010_create_documenti_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('documenti', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('volontario_id')->constrained("users")->onDelete('cascade');
+            $table->foreignId('volontario_id')->constrained('volontari')->onDelete('cascade');
             $table->foreignId('caricato_da')->constrained('users')->onDelete('cascade');
             
             // Informazioni Documento

--- a/database/migrations/2024_01_01_000012_create_partecipazioni_eventi_table.php
+++ b/database/migrations/2024_01_01_000012_create_partecipazioni_eventi_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('partecipazioni_eventi', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('evento_id')->constrained("users")->onDelete('cascade');
+            $table->foreignId('evento_id')->constrained('eventi')->onDelete('cascade');
             $table->foreignId('user_id')->constrained("users")->onDelete('cascade');
             
             // Stato Partecipazione

--- a/database/migrations/2024_01_01_000013_create_tickets_table.php
+++ b/database/migrations/2024_01_01_000013_create_tickets_table.php
@@ -59,8 +59,8 @@ return new class extends Migration
             $table->integer('tempo_risoluzione_ore')->nullable(); // Calcolato automaticamente
             
             // Dettagli Tecnici
-            $table->foreignId('mezzo_id')->nullable()->constrained("users")->onDelete('set null');
-            $table->foreignId('dpi_id')->nullable()->constrained("users")->onDelete('set null');
+            $table->foreignId('mezzo_id')->nullable()->constrained('mezzi')->onDelete('set null');
+            $table->foreignId('dpi_id')->nullable()->constrained('dpi')->onDelete('set null');
             $table->foreignId('articolo_magazzino_id')->nullable()->constrained('magazzino')->onDelete('set null');
             $table->string('ubicazione_problema')->nullable();
             

--- a/database/migrations/2024_01_01_000014_create_allegati_tickets_table.php
+++ b/database/migrations/2024_01_01_000014_create_allegati_tickets_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('allegati_tickets', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('ticket_id')->constrained("users")->onDelete('cascade');
+            $table->foreignId('ticket_id')->constrained('tickets')->onDelete('cascade');
             $table->foreignId('user_id')->constrained("users")->onDelete('cascade'); // Chi ha caricato
             
             // File Info


### PR DESCRIPTION
## Summary
- correct table references in multiple migrations

## Testing
- `./vendor/bin/phpunit` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d3fce130832488a70c696ec713cb