### PR TITLE
Add SoftDeletes columns for various tables

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Carbon\Carbon;
 
 class User extends Authenticatable

--- a/database/migrations/2025_07_01_000001_add_soft_deletes_to_volontari_table.php
+++ b/database/migrations/2025_07_01_000001_add_soft_deletes_to_volontari_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('volontari', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('volontari', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/database/migrations/2025_07_01_000002_add_soft_deletes_to_mezzi_table.php
+++ b/database/migrations/2025_07_01_000002_add_soft_deletes_to_mezzi_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('mezzi', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('mezzi', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/database/migrations/2025_07_01_000003_add_soft_deletes_to_magazzino_table.php
+++ b/database/migrations/2025_07_01_000003_add_soft_deletes_to_magazzino_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('magazzino', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('magazzino', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/database/migrations/2025_07_01_000004_add_soft_deletes_to_dpi_table.php
+++ b/database/migrations/2025_07_01_000004_add_soft_deletes_to_dpi_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('dpi', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('dpi', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/database/migrations/2025_07_01_000005_add_soft_deletes_to_eventi_table.php
+++ b/database/migrations/2025_07_01_000005_add_soft_deletes_to_eventi_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('eventi', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('eventi', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- remove stray SoftDeletes import from `User` model
- allow soft deletions on `volontari`, `mezzi`, `magazzino`, `dpi` and `eventi`

## Testing
- `./vendor/bin/phpunit --version` *(fails: php not installed)*
- `./vendor/bin/pint --version` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6862fdc4804c8324ba23555c4bed7376