### PR TITLE
Fix naming and query issues

### DIFF
--- a/app/Http/Controllers/VolontariController.php
+++ b/app/Http/Controllers/VolontariController.php
@@ -109,7 +109,7 @@ class VolontariController extends Controller
     // ===================================
     public function create()
     {
-        $numeroTessera = Volontario::generaNumeraTessera();
+        $numeroTessera = Volontario::generaNumeroTessera();
         
         return view('volontari.create', compact('numeroTessera'));
     }
@@ -175,7 +175,7 @@ class VolontariController extends Controller
             // Crea volontario
             $volontario = Volontario::create([
                 'user_id' => $user->id,
-                'tessera_numero' => $validated['tessera_numero'] ?: Volontario::generaNumeraTessera(),
+                'tessera_numero' => $validated['tessera_numero'] ?: Volontario::generaNumeroTessera(),
                 'data_iscrizione' => $validated['data_iscrizione'],
                 'data_visita_medica' => $validated['data_visita_medica'],
                 'scadenza_visita_medica' => $validated['scadenza_visita_medica'],

--- a/app/Models/ChecklistCompilata.php
+++ b/app/Models/ChecklistCompilata.php
@@ -112,7 +112,7 @@ class ChecklistCompilata extends Model
         return $query->where('completata', true);
     }
 
-    public function scopeConAномalie($query)
+    public function scopeConAnomalie($query)
     {
         return $query->whereNotNull('anomalie_riscontrate')
                     ->whereJsonLength('anomalie_riscontrate', '>', 0);
@@ -127,7 +127,7 @@ class ChecklistCompilata extends Model
     // METODI UTILITY
     // ===================================
 
-    public function hasAnomaliae()
+    public function hasAnomalie()
     {
         return $this->numero_anomalie > 0;
     }

--- a/app/Models/MovimentoMagazzino.php
+++ b/app/Models/MovimentoMagazzino.php
@@ -217,9 +217,9 @@ class MovimentoMagazzino extends Model
         if (!$articolo) return;
 
         if ($this->isCarico()) {
-            $articolo->increment('quantita_disponibile', $this->quantita);
+            $articolo->increment('quantita_attuale', $this->quantita);
         } else {
-            $articolo->decrement('quantita_disponibile', $this->quantita);
+            $articolo->decrement('quantita_attuale', $this->quantita);
         }
     }
 }

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -571,10 +571,13 @@ class Ticket extends Model
     public function scopeInRitardo($query)
     {
         return $query->whereIn('stato', ['aperto', 'assegnato', 'in_corso'])
-                     ->get()
-                     ->filter(function($ticket) {
-                         return $ticket->in_ritardo;
-                     });
+                     ->whereRaw(
+                         "TIMESTAMPDIFF(HOUR, data_apertura, NOW()) > CASE priorita " .
+                         "WHEN 'critica' THEN 4 " .
+                         "WHEN 'alta' THEN 24 " .
+                         "WHEN 'media' THEN 72 " .
+                         "ELSE 168 END"
+                     );
     }
 
     public function scopeRicerca($query, $termine)

--- a/app/Models/Volontario.php
+++ b/app/Models/Volontario.php
@@ -115,7 +115,7 @@ class Volontario extends Model
     // METODI UTILITY
     // ===================================
 
-    public static function generaNumeraTessera()
+    public static function generaNumeroTessera()
     {
         $anno = now()->year;
         $ultimoNumero = self::where('tessera_numero', 'like', $anno . '%')->max('tessera_numero');


### PR DESCRIPTION
## Summary
- rename `Volontario::generaNumeraTessera` to `generaNumeroTessera`
- update controller calls to new method name
- fix typos in `ChecklistCompilata` scope and utility method
- correct column used in `MovimentoMagazzino::aggiornaQuantitaArticolo`
- refactor `Ticket::scopeInRitardo` to filter at DB level

## Testing
- `php artisan test` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fdc99f3083248f643f79254ad683