### PR TITLE
Add bootstrap views for eventi

### DIFF
--- a/resources/views/eventi/create.blade.php
+++ b/resources/views/eventi/create.blade.php
@@ -1,1 +1,67 @@
-<h1>Crea evento</h1>
+@extends('layouts.app')
+
+@section('page-title', 'Nuovo Evento')
+
+@section('content')
+<div class="container-fluid">
+    <form action="{{ route('eventi.store') }}" method="POST">
+        @csrf
+        <div class="card shadow-sm">
+            <div class="card-header">
+                <h3 class="card-title">Crea Evento</h3>
+            </div>
+            <div class="card-body">
+                <div class="mb-3">
+                    <label class="form-label">Titolo</label>
+                    <input type="text" name="titolo" class="form-control" value="{{ old('titolo') }}" required>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Descrizione</label>
+                    <textarea name="descrizione" rows="4" class="form-control" required>{{ old('descrizione') }}</textarea>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Tipo</label>
+                    <select name="tipo_evento" class="form-select" required>
+                        <option value="">Seleziona</option>
+                        @foreach($tipi_evento as $key => $label)
+                            <option value="{{ $key }}" {{ old('tipo_evento') == $key ? 'selected' : '' }}>{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-6 mb-3">
+                        <label class="form-label">Data Inizio</label>
+                        <input type="datetime-local" name="data_inizio" class="form-control" value="{{ old('data_inizio') }}" required>
+                    </div>
+                    <div class="col-md-6 mb-3">
+                        <label class="form-label">Data Fine</label>
+                        <input type="datetime-local" name="data_fine" class="form-control" value="{{ old('data_fine') }}" required>
+                    </div>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Luogo</label>
+                    <input type="text" name="luogo" class="form-control" value="{{ old('luogo') }}">
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Max Partecipanti</label>
+                    <input type="number" name="max_partecipanti" class="form-control" value="{{ old('max_partecipanti') }}">
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Note</label>
+                    <textarea name="note" rows="3" class="form-control">{{ old('note') }}</textarea>
+                </div>
+            </div>
+            <div class="card-footer text-end">
+                <a href="{{ route('eventi.index') }}" class="btn btn-secondary">Annulla</a>
+                <button type="submit" class="btn btn-primary">Salva</button>
+            </div>
+        </div>
+    </form>
+</div>
+@endsection

--- a/resources/views/eventi/edit.blade.php
+++ b/resources/views/eventi/edit.blade.php
@@ -1,1 +1,68 @@
-<h1>Modifica evento</h1>
+@extends('layouts.app')
+
+@section('page-title', 'Modifica Evento')
+
+@section('content')
+<div class="container-fluid">
+    <form action="{{ route('eventi.update', $evento->id) }}" method="POST">
+        @csrf
+        @method('PUT')
+        <div class="card shadow-sm">
+            <div class="card-header">
+                <h3 class="card-title">Modifica Evento</h3>
+            </div>
+            <div class="card-body">
+                <div class="mb-3">
+                    <label class="form-label">Titolo</label>
+                    <input type="text" name="titolo" class="form-control" value="{{ old('titolo', $evento->titolo) }}" required>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Descrizione</label>
+                    <textarea name="descrizione" rows="4" class="form-control" required>{{ old('descrizione', $evento->descrizione) }}</textarea>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Tipo</label>
+                    <select name="tipo_evento" class="form-select" required>
+                        <option value="">Seleziona</option>
+                        @foreach($tipi_evento as $key => $label)
+                            <option value="{{ $key }}" {{ (old('tipo_evento', $evento->tipo_evento ?? $evento->tipo) == $key) ? 'selected' : '' }}>{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-6 mb-3">
+                        <label class="form-label">Data Inizio</label>
+                        <input type="datetime-local" name="data_inizio" class="form-control" value="{{ old('data_inizio', $evento->data_inizio->format('Y-m-d\TH:i')) }}" required>
+                    </div>
+                    <div class="col-md-6 mb-3">
+                        <label class="form-label">Data Fine</label>
+                        <input type="datetime-local" name="data_fine" class="form-control" value="{{ old('data_fine', $evento->data_fine->format('Y-m-d\TH:i')) }}" required>
+                    </div>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Luogo</label>
+                    <input type="text" name="luogo" class="form-control" value="{{ old('luogo', $evento->luogo) }}">
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Max Partecipanti</label>
+                    <input type="number" name="max_partecipanti" class="form-control" value="{{ old('max_partecipanti', $evento->max_partecipanti) }}">
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Note</label>
+                    <textarea name="note" rows="3" class="form-control">{{ old('note', $evento->note) }}</textarea>
+                </div>
+            </div>
+            <div class="card-footer text-end">
+                <a href="{{ route('eventi.show', $evento->id) }}" class="btn btn-secondary">Annulla</a>
+                <button type="submit" class="btn btn-primary">Aggiorna</button>
+            </div>
+        </div>
+    </form>
+</div>
+@endsection

--- a/resources/views/eventi/index.blade.php
+++ b/resources/views/eventi/index.blade.php
@@ -1,1 +1,65 @@
-<h1>Lista eventi</h1>
+@extends('layouts.app')
+
+@section('page-title', 'Eventi')
+
+@section('content')
+<div class="container-fluid">
+    <div class="card shadow-sm">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <h3 class="card-title">📅 Eventi</h3>
+            <a href="{{ route('eventi.create') }}" class="btn btn-success">
+                <i class="bi bi-plus-circle"></i> Nuovo Evento
+            </a>
+        </div>
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Titolo</th>
+                            <th>Tipo</th>
+                            <th>Inizio</th>
+                            <th>Fine</th>
+                            <th>Stato</th>
+                            <th class="text-end">Azioni</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($eventi as $evento)
+                        <tr>
+                            <td>{{ $evento->titolo }}</td>
+                            <td>{{ ucfirst(str_replace('_',' ', $evento->tipo_evento ?? $evento->tipo)) }}</td>
+                            <td>{{ $evento->data_inizio->format('d/m/Y H:i') }}</td>
+                            <td>{{ $evento->data_fine->format('d/m/Y H:i') }}</td>
+                            <td><span class="badge bg-primary">{{ ucfirst($evento->stato) }}</span></td>
+                            <td class="text-end">
+                                <a href="{{ route('eventi.show', $evento->id) }}" class="btn btn-outline-primary btn-sm">
+                                    <i class="bi bi-eye"></i>
+                                </a>
+                                <a href="{{ route('eventi.edit', $evento->id) }}" class="btn btn-outline-warning btn-sm">
+                                    <i class="bi bi-pencil"></i>
+                                </a>
+                                <form action="{{ route('eventi.destroy', $evento->id) }}" method="POST" class="d-inline-block" onsubmit="return confirm('Eliminare questo evento?');">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="btn btn-outline-danger btn-sm">
+                                        <i class="bi bi-trash"></i>
+                                    </button>
+                                </form>
+                            </td>
+                        </tr>
+                        @empty
+                        <tr>
+                            <td colspan="6" class="text-center text-muted py-3">Nessun evento trovato.</td>
+                        </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="card-footer">
+            {{ $eventi->links() }}
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/eventi/show.blade.php
+++ b/resources/views/eventi/show.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.app')
+
+@section('page-title', 'Dettaglio Evento')
+
+@section('content')
+<div class="container-fluid">
+    <div class="card shadow-sm">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <h3 class="card-title">{{ $evento->titolo }}</h3>
+            <div>
+                <a href="{{ route('eventi.edit', $evento->id) }}" class="btn btn-outline-warning btn-sm">
+                    <i class="bi bi-pencil"></i> Modifica
+                </a>
+                <a href="{{ route('eventi.index') }}" class="btn btn-outline-secondary btn-sm">
+                    <i class="bi bi-arrow-left"></i> Indietro
+                </a>
+            </div>
+        </div>
+        <div class="card-body">
+            <dl class="row mb-0">
+                <dt class="col-sm-3">Tipo</dt>
+                <dd class="col-sm-9">{{ ucfirst(str_replace('_',' ', $evento->tipo_evento ?? $evento->tipo)) }}</dd>
+
+                <dt class="col-sm-3">Periodo</dt>
+                <dd class="col-sm-9">
+                    {{ $evento->data_inizio->format('d/m/Y H:i') }} -
+                    {{ $evento->data_fine->format('d/m/Y H:i') }}
+                </dd>
+
+                <dt class="col-sm-3">Luogo</dt>
+                <dd class="col-sm-9">{{ $evento->luogo }}</dd>
+
+                <dt class="col-sm-3">Stato</dt>
+                <dd class="col-sm-9"><span class="badge bg-primary">{{ ucfirst($evento->stato) }}</span></dd>
+
+                <dt class="col-sm-3">Descrizione</dt>
+                <dd class="col-sm-9">{{ $evento->descrizione }}</dd>
+            </dl>
+        </div>
+    </div>
+</div>
+@endsection


### PR DESCRIPTION
## Summary
- replace blank eventi views with bootstrap dashboard templates
- add new show view for events

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68631cb1734c8324b6308d9a09afb292