### PR TITLE
Add styled notification templates

### DIFF
--- a/resources/views/notifiche/create.blade.php
+++ b/resources/views/notifiche/create.blade.php
@@ -1,0 +1,82 @@
+@extends('layouts.app')
+
+@section('title', 'Nuova Notifica')
+@section('page-title', 'Crea Notifica')
+
+@section('content')
+<div class="container-fluid">
+    <div class="card shadow-sm">
+        <div class="card-header">
+            <h3 class="card-title">Invia Notifica</h3>
+        </div>
+        <div class="card-body">
+            <form method="POST" action="{{ route('notifiche.store') }}">
+                @csrf
+                <div class="mb-3">
+                    <label class="form-label">Destinatari</label>
+                    <select name="destinatari[]" class="form-select" multiple required>
+                        @foreach($utenti as $utente)
+                            <option value="{{ $utente->id }}" @selected(in_array($utente->id, old('destinatari', [])))>
+                                {{ $utente->nome_completo }} ({{ $utente->ruolo_label }})
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Tipo Notifica</label>
+                    <select name="tipo" class="form-select" required>
+                        @foreach($tipi_notifiche as $key => $label)
+                            <option value="{{ $key }}" @selected(old('tipo')=== $key)>{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Titolo</label>
+                    <input type="text" name="titolo" class="form-control" value="{{ old('titolo') }}" required>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Messaggio</label>
+                    <textarea name="messaggio" class="form-control" rows="4" required>{{ old('messaggio') }}</textarea>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Priorità</label>
+                    <select name="priorita" class="form-select" required>
+                        @foreach($priorita_levels as $level => $label)
+                            <option value="{{ $level }}" @selected(old('priorita')=== $level)>{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="row">
+                    <div class="col-md-6 mb-3">
+                        <label class="form-label">URL Azione</label>
+                        <input type="url" name="url_azione" class="form-control" value="{{ old('url_azione') }}">
+                    </div>
+                    <div class="col-md-6 mb-3">
+                        <label class="form-label">Testo Azione</label>
+                        <input type="text" name="testo_azione" class="form-control" value="{{ old('testo_azione') }}">
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-6 mb-3">
+                        <label class="form-label">Scade il</label>
+                        <input type="date" name="scade_il" class="form-control" value="{{ old('scade_il') }}">
+                    </div>
+                    <div class="col-md-3 mb-3 form-check mt-4">
+                        <input type="checkbox" name="invia_email" class="form-check-input" id="chkEmail" value="1" {{ old('invia_email') ? 'checked' : '' }}>
+                        <label class="form-check-label" for="chkEmail">Invia anche via email</label>
+                    </div>
+                    <div class="col-md-3 mb-3 form-check mt-4">
+                        <input type="checkbox" name="invia_push" class="form-check-input" id="chkPush" value="1" {{ old('invia_push') ? 'checked' : '' }}>
+                        <label class="form-check-label" for="chkPush">Invia notifica push</label>
+                    </div>
+                </div>
+                <div class="text-end">
+                    <a href="{{ route('notifiche.index') }}" class="btn btn-secondary">Annulla</a>
+                    <button type="submit" class="btn btn-primary">Invia</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+@endsection
+

--- a/resources/views/notifiche/index.blade.php
+++ b/resources/views/notifiche/index.blade.php
@@ -1,1 +1,104 @@
-<h1>Notifiche utente</h1>
+@extends('layouts.app')
+
+@section('title', 'Notifiche')
+@section('page-title', 'Centro Notifiche')
+
+@section('content')
+<div class="container-fluid">
+    <div class="row mb-4">
+        <div class="col-md-3 col-sm-6 mb-3">
+            <div class="card border-0 shadow-sm text-center">
+                <div class="card-body">
+                    <div class="text-muted mb-1">Totali</div>
+                    <h3 class="mb-0">{{ $stats['totali'] ?? 0 }}</h3>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3 col-sm-6 mb-3">
+            <div class="card border-0 shadow-sm text-center">
+                <div class="card-body">
+                    <div class="text-muted mb-1">Non Lette</div>
+                    <h3 class="mb-0">{{ $stats['non_lette'] ?? 0 }}</h3>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3 col-sm-6 mb-3">
+            <div class="card border-0 shadow-sm text-center">
+                <div class="card-body">
+                    <div class="text-muted mb-1">Oggi</div>
+                    <h3 class="mb-0">{{ $stats['oggi'] ?? 0 }}</h3>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3 col-sm-6 mb-3">
+            <div class="card border-0 shadow-sm text-center">
+                <div class="card-body">
+                    <div class="text-muted mb-1">Questa settimana</div>
+                    <h3 class="mb-0">{{ $stats['questa_settimana'] ?? 0 }}</h3>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <h3 class="card-title">🔔 Notifiche</h3>
+            <a href="{{ route('notifiche.create') }}" class="btn btn-success">
+                <i class="bi bi-plus-circle"></i> Nuova Notifica
+            </a>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-bordered table-hover mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Titolo</th>
+                            <th>Tipo</th>
+                            <th>Priorità</th>
+                            <th>Data</th>
+                            <th>Stato</th>
+                            <th>Azioni</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($notifiche as $notifica)
+                        <tr>
+                            <td>{{ $notifica->titolo }}</td>
+                            <td>{{ $tipi_notifiche[$notifica->tipo] ?? $notifica->tipo }}</td>
+                            <td>{{ ucfirst($notifica->priorita) }}</td>
+                            <td>{{ $notifica->created_at->format('d/m/Y H:i') }}</td>
+                            <td>
+                                @if($notifica->read_at)
+                                    <span class="badge bg-success">Letta</span>
+                                @else
+                                    <span class="badge bg-warning text-dark">Non letta</span>
+                                @endif
+                            </td>
+                            <td>
+                                <a href="{{ route('notifiche.show', $notifica->id) }}" class="btn btn-primary btn-sm">
+                                    <i class="bi bi-eye"></i>
+                                </a>
+                                <form action="{{ route('notifiche.destroy', $notifica->id) }}" method="POST" class="d-inline-block" onsubmit="return confirm('Eliminare questa notifica?');">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button class="btn btn-danger btn-sm"><i class="bi bi-trash"></i></button>
+                                </form>
+                            </td>
+                        </tr>
+                        @empty
+                        <tr>
+                            <td colspan="6" class="text-center text-muted">Nessuna notifica trovata.</td>
+                        </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="mt-3">
+                {{ $notifiche->links() }}
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+

--- a/resources/views/notifiche/show.blade.php
+++ b/resources/views/notifiche/show.blade.php
@@ -1,0 +1,30 @@
+@extends('layouts.app')
+
+@section('title', 'Dettaglio Notifica')
+@section('page-title', 'Notifica')
+
+@section('content')
+<div class="container-fluid">
+    <div class="card shadow-sm">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <h3 class="card-title">{{ $notifica->titolo }}</h3>
+            <a href="{{ route('notifiche.index') }}" class="btn btn-secondary btn-sm">
+                <i class="bi bi-arrow-left"></i> Indietro
+            </a>
+        </div>
+        <div class="card-body">
+            <p class="text-muted">Tipo: {{ $notifica->tipo }}</p>
+            <p class="text-muted">Priorità: {{ ucfirst($notifica->priorita) }}</p>
+            <p class="text-muted">Data: {{ $notifica->created_at->format('d/m/Y H:i') }}</p>
+            <hr>
+            <p>{{ $notifica->messaggio }}</p>
+            @if($notifica->url_azione)
+                <a href="{{ $notifica->url_azione }}" class="btn btn-primary" target="_blank">
+                    {{ $notifica->testo_azione ?? 'Apri collegamento' }}
+                </a>
+            @endif
+        </div>
+    </div>
+</div>
+@endsection
+


### PR DESCRIPTION
## Summary
- style notifications index with dashboard cards and table
- add notification creation form
- add notification detail page

## Testing
- `composer test` *(fails: composer not installed)*
- `./vendor/bin/phpunit --version` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68631cb7147083248bd4e8603d102df3