### PR TITLE
Add mezzo forms and show page

### DIFF
--- a/resources/views/mezzi/create.blade.php
+++ b/resources/views/mezzi/create.blade.php
@@ -1,1 +1,102 @@
-<h1>Nuovo mezzo - in costruzione</h1>
+@extends('layouts.app')
+
+@section('title', 'Nuovo Mezzo')
+@section('page-title', 'Nuovo Mezzo')
+
+@section('page-actions')
+    <a href="{{ route('mezzi.index') }}" class="btn btn-secondary">
+        <i class="bi bi-arrow-left"></i> Indietro
+    </a>
+@endsection
+
+@section('content')
+<div class="container-fluid">
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <form method="POST" action="{{ route('mezzi.store') }}">
+                @csrf
+                <div class="row mb-3">
+                    <div class="col-md-4">
+                        <label class="form-label">Targa</label>
+                        <input type="text" name="targa" value="{{ old('targa') }}" class="form-control" required>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Tipo</label>
+                        <select name="tipo" class="form-select" required>
+                            <option value="">Seleziona...</option>
+                            <option value="ambulanza_a" {{ old('tipo')=='ambulanza_a' ? 'selected' : '' }}>Ambulanza Tipo A</option>
+                            <option value="ambulanza_b" {{ old('tipo')=='ambulanza_b' ? 'selected' : '' }}>Ambulanza Tipo B</option>
+                            <option value="auto_medica" {{ old('tipo')=='auto_medica' ? 'selected' : '' }}>Auto Medica</option>
+                            <option value="auto_servizio" {{ old('tipo')=='auto_servizio' ? 'selected' : '' }}>Auto di Servizio</option>
+                            <option value="furgone" {{ old('tipo')=='furgone' ? 'selected' : '' }}>Furgone</option>
+                            <option value="altro" {{ old('tipo')=='altro' ? 'selected' : '' }}>Altro</option>
+                        </select>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Anno</label>
+                        <input type="number" name="anno" value="{{ old('anno') }}" class="form-control" required>
+                    </div>
+                </div>
+                <div class="row mb-3">
+                    <div class="col-md-4">
+                        <label class="form-label">Marca</label>
+                        <input type="text" name="marca" value="{{ old('marca') }}" class="form-control" required>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Modello</label>
+                        <input type="text" name="modello" value="{{ old('modello') }}" class="form-control" required>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Colore</label>
+                        <input type="text" name="colore" value="{{ old('colore') }}" class="form-control" required>
+                    </div>
+                </div>
+                <div class="row mb-3">
+                    <div class="col-md-4">
+                        <label class="form-label">Alimentazione</label>
+                        <select name="alimentazione" class="form-select" required>
+                            <option value="benzina" {{ old('alimentazione')=='benzina' ? 'selected' : '' }}>Benzina</option>
+                            <option value="diesel" {{ old('alimentazione')=='diesel' ? 'selected' : '' }}>Diesel</option>
+                            <option value="gpl" {{ old('alimentazione')=='gpl' ? 'selected' : '' }}>GPL</option>
+                            <option value="metano" {{ old('alimentazione')=='metano' ? 'selected' : '' }}>Metano</option>
+                            <option value="elettrico" {{ old('alimentazione')=='elettrico' ? 'selected' : '' }}>Elettrico</option>
+                            <option value="ibrido" {{ old('alimentazione')=='ibrido' ? 'selected' : '' }}>Ibrido</option>
+                        </select>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Km Attuali</label>
+                        <input type="number" name="km_attuali" value="{{ old('km_attuali') }}" class="form-control" required>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Intervallo Tagliando (km)</label>
+                        <input type="number" name="intervallo_tagliando" value="{{ old('intervallo_tagliando') }}" class="form-control" required>
+                    </div>
+                </div>
+                <div class="row mb-3">
+                    <div class="col-md-4">
+                        <label class="form-label">Scadenza Revisione</label>
+                        <input type="date" name="scadenza_revisione" value="{{ old('scadenza_revisione') }}" class="form-control" required>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Scadenza Assicurazione</label>
+                        <input type="date" name="scadenza_assicurazione" value="{{ old('scadenza_assicurazione') }}" class="form-control" required>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Scadenza Bollo</label>
+                        <input type="date" name="scadenza_bollo" value="{{ old('scadenza_bollo') }}" class="form-control">
+                    </div>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Note</label>
+                    <textarea name="note" class="form-control" rows="3">{{ old('note') }}</textarea>
+                </div>
+                <div class="text-end">
+                    <button type="submit" class="btn btn-success">
+                        <i class="bi bi-check-lg"></i> Salva
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/mezzi/edit.blade.php
+++ b/resources/views/mezzi/edit.blade.php
@@ -1,1 +1,102 @@
-<h1>Modifica mezzo - in costruzione</h1>
+@extends('layouts.app')
+
+@section('title', 'Modifica Mezzo')
+@section('page-title', 'Modifica Mezzo')
+
+@section('page-actions')
+    <a href="{{ route('mezzi.index') }}" class="btn btn-secondary">
+        <i class="bi bi-arrow-left"></i> Indietro
+    </a>
+@endsection
+
+@section('content')
+<div class="container-fluid">
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <form method="POST" action="{{ route('mezzi.update', $mezzo->id) }}">
+                @csrf
+                @method('PUT')
+                <div class="row mb-3">
+                    <div class="col-md-4">
+                        <label class="form-label">Targa</label>
+                        <input type="text" name="targa" value="{{ old('targa', $mezzo->targa) }}" class="form-control" required>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Tipo</label>
+                        <select name="tipo" class="form-select" required>
+                            <option value="ambulanza_a" {{ old('tipo', $mezzo->tipo)=='ambulanza_a' ? 'selected' : '' }}>Ambulanza Tipo A</option>
+                            <option value="ambulanza_b" {{ old('tipo', $mezzo->tipo)=='ambulanza_b' ? 'selected' : '' }}>Ambulanza Tipo B</option>
+                            <option value="auto_medica" {{ old('tipo', $mezzo->tipo)=='auto_medica' ? 'selected' : '' }}>Auto Medica</option>
+                            <option value="auto_servizio" {{ old('tipo', $mezzo->tipo)=='auto_servizio' ? 'selected' : '' }}>Auto di Servizio</option>
+                            <option value="furgone" {{ old('tipo', $mezzo->tipo)=='furgone' ? 'selected' : '' }}>Furgone</option>
+                            <option value="altro" {{ old('tipo', $mezzo->tipo)=='altro' ? 'selected' : '' }}>Altro</option>
+                        </select>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Anno</label>
+                        <input type="number" name="anno" value="{{ old('anno', $mezzo->anno) }}" class="form-control" required>
+                    </div>
+                </div>
+                <div class="row mb-3">
+                    <div class="col-md-4">
+                        <label class="form-label">Marca</label>
+                        <input type="text" name="marca" value="{{ old('marca', $mezzo->marca) }}" class="form-control" required>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Modello</label>
+                        <input type="text" name="modello" value="{{ old('modello', $mezzo->modello) }}" class="form-control" required>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Colore</label>
+                        <input type="text" name="colore" value="{{ old('colore', $mezzo->colore) }}" class="form-control" required>
+                    </div>
+                </div>
+                <div class="row mb-3">
+                    <div class="col-md-4">
+                        <label class="form-label">Alimentazione</label>
+                        <select name="alimentazione" class="form-select" required>
+                            <option value="benzina" {{ old('alimentazione', $mezzo->alimentazione)=='benzina' ? 'selected' : '' }}>Benzina</option>
+                            <option value="diesel" {{ old('alimentazione', $mezzo->alimentazione)=='diesel' ? 'selected' : '' }}>Diesel</option>
+                            <option value="gpl" {{ old('alimentazione', $mezzo->alimentazione)=='gpl' ? 'selected' : '' }}>GPL</option>
+                            <option value="metano" {{ old('alimentazione', $mezzo->alimentazione)=='metano' ? 'selected' : '' }}>Metano</option>
+                            <option value="elettrico" {{ old('alimentazione', $mezzo->alimentazione)=='elettrico' ? 'selected' : '' }}>Elettrico</option>
+                            <option value="ibrido" {{ old('alimentazione', $mezzo->alimentazione)=='ibrido' ? 'selected' : '' }}>Ibrido</option>
+                        </select>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Km Attuali</label>
+                        <input type="number" name="km_attuali" value="{{ old('km_attuali', $mezzo->km_attuali) }}" class="form-control" required>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Intervallo Tagliando (km)</label>
+                        <input type="number" name="intervallo_tagliando" value="{{ old('intervallo_tagliando', $mezzo->intervallo_tagliando) }}" class="form-control" required>
+                    </div>
+                </div>
+                <div class="row mb-3">
+                    <div class="col-md-4">
+                        <label class="form-label">Scadenza Revisione</label>
+                        <input type="date" name="scadenza_revisione" value="{{ old('scadenza_revisione', optional($mezzo->scadenza_revisione)->format('Y-m-d')) }}" class="form-control" required>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Scadenza Assicurazione</label>
+                        <input type="date" name="scadenza_assicurazione" value="{{ old('scadenza_assicurazione', optional($mezzo->scadenza_assicurazione)->format('Y-m-d')) }}" class="form-control" required>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Scadenza Bollo</label>
+                        <input type="date" name="scadenza_bollo" value="{{ old('scadenza_bollo', optional($mezzo->scadenza_bollo)->format('Y-m-d')) }}" class="form-control">
+                    </div>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Note</label>
+                    <textarea name="note" class="form-control" rows="3">{{ old('note', $mezzo->note) }}</textarea>
+                </div>
+                <div class="text-end">
+                    <button type="submit" class="btn btn-success">
+                        <i class="bi bi-check-lg"></i> Aggiorna
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/mezzi/show.blade.php
+++ b/resources/views/mezzi/show.blade.php
@@ -1,0 +1,46 @@
+@extends('layouts.app')
+
+@section('title', 'Dettaglio Mezzo')
+@section('page-title', 'Dettaglio Mezzo')
+
+@section('page-actions')
+    <a href="{{ route('mezzi.index') }}" class="btn btn-secondary">
+        <i class="bi bi-arrow-left"></i> Indietro
+    </a>
+    @can('permission', ['mezzi', 'modifica'])
+    <a href="{{ route('mezzi.edit', $mezzo->id) }}" class="btn btn-primary">
+        <i class="bi bi-pencil"></i> Modifica
+    </a>
+    @endcan
+@endsection
+
+@section('content')
+<div class="container-fluid">
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <h5 class="card-title mb-4">{{ $mezzo->targa }} - {{ $mezzo->tipo_descrizione }}</h5>
+            <div class="row mb-3">
+                <div class="col-md-4">
+                    <strong>Marca:</strong> {{ $mezzo->marca }}<br>
+                    <strong>Modello:</strong> {{ $mezzo->modello }}<br>
+                    <strong>Anno:</strong> {{ $mezzo->anno }}
+                </div>
+                <div class="col-md-4">
+                    <strong>Km attuali:</strong> {{ number_format($mezzo->km_attuali) }}<br>
+                    <strong>Stato:</strong> {{ $mezzo->stato_descrizione }}<br>
+                    <strong>Posizione:</strong> {{ $mezzo->posizione_attuale ?? '-' }}
+                </div>
+                <div class="col-md-4">
+                    <strong>Revisione:</strong> {{ optional($mezzo->scadenza_revisione)->format('d/m/Y') }}<br>
+                    <strong>Assicurazione:</strong> {{ optional($mezzo->scadenza_assicurazione)->format('d/m/Y') }}<br>
+                    <strong>Bollo:</strong> {{ optional($mezzo->scadenza_bollo)->format('d/m/Y') }}
+                </div>
+            </div>
+            <div class="mb-3">
+                <strong>Note:</strong><br>
+                {{ $mezzo->note ?? '-' }}
+            </div>
+        </div>
+    </div>
+</div>
+@endsection


### PR DESCRIPTION
## Summary
- implement a complete create form for mezzi using the dashboard layout
- add an edit form with pre-filled data
- introduce a simple show page for vehicle details
- keep the existing mezzi table component intact

## Testing
- `./vendor/bin/phpunit` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68631cb2f4348324a93d76d541b3b4b8